### PR TITLE
nginx changes

### DIFF
--- a/config/nginx_stakepool_production.conf
+++ b/config/nginx_stakepool_production.conf
@@ -61,6 +61,7 @@ server {
         add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
         add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
      }
+
   }
 
 }

--- a/config/nginx_stakepool_production.conf
+++ b/config/nginx_stakepool_production.conf
@@ -1,0 +1,74 @@
+
+# Rate limiting the requests
+limit_req_zone $binary_remote_addr zone=mylimit:10m rate=4r/s;
+# 4 request per second (/json, /config, /metrics = 3 pages loaded simultaneously)
+
+# Caching the requests
+proxy_cache_path  /tmp/nginx  levels=1:2    keys_zone=STATIC:10m
+inactive=24h  max_size=1g;
+
+server {
+  listen 80;
+  listen [::]:80;
+
+  server_name $hostname;
+
+  location / {
+      limit_req zone=mylimit;
+      proxy_pass http://localhost:9000/;
+      proxy_buffering        on;
+      proxy_cache            STATIC;
+      proxy_cache_valid      200  2m;
+      proxy_cache_use_stale  error timeout invalid_header updating
+                            http_500 http_502 http_503 http_504;
+
+      # CORS allow-any website to embed our data
+      if ($request_method = 'OPTIONS') {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+
+        # Custom headers and headers various browsers *should* be OK with but aren't
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+        add_header 'Access-Control-Max-Age' 1728000; # Tell client that this pre-flight info is valid for 20 days
+        add_header 'Content-Length' 0;
+        return 204;
+     }
+     if ($request_method = 'GET') {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+        add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+     }
+  }  
+  
+  # Any route that matches /test (also includes /testnet) will route to the testnet version.
+  location /test {
+      limit_req zone=mylimit;
+      proxy_pass http://localhost:9001/;
+      proxy_buffering        on;
+      proxy_cache            STATIC;
+      proxy_cache_valid      200  2m;
+      proxy_cache_use_stale  error timeout invalid_header updating
+                            http_500 http_502 http_503 http_504;
+
+      # CORS allow-any website to embed our data
+      if ($request_method = 'OPTIONS') {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+
+        # Custom headers and headers various browsers *should* be OK with but aren't
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+        add_header 'Access-Control-Max-Age' 1728000; # Tell client that this pre-flight info is valid for 20 days
+        add_header 'Content-Length' 0;
+        return 204;
+     }
+     if ($request_method = 'GET') {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+        add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+     }
+  }
+
+}
+

--- a/config/nginx_stakepool_production.conf
+++ b/config/nginx_stakepool_production.conf
@@ -1,8 +1,3 @@
-
-# Rate limiting the requests
-limit_req_zone $binary_remote_addr zone=mylimit:10m rate=4r/s;
-# 4 request per second (/json, /config, /metrics = 3 pages loaded simultaneously)
-
 # Caching the requests
 proxy_cache_path  /tmp/nginx  levels=1:2    keys_zone=STATIC:10m
 inactive=24h  max_size=1g;
@@ -14,7 +9,6 @@ server {
   server_name $hostname;
 
   location / {
-      limit_req zone=mylimit;
       proxy_pass http://localhost:9000/;
       proxy_buffering        on;
       proxy_cache            STATIC;
@@ -43,7 +37,6 @@ server {
   
   # Any route that matches /test (also includes /testnet) will route to the testnet version.
   location /test {
-      limit_req zone=mylimit;
       proxy_pass http://localhost:9001/;
       proxy_buffering        on;
       proxy_cache            STATIC;

--- a/config/nginx_stakepool_production.conf
+++ b/config/nginx_stakepool_production.conf
@@ -19,19 +19,10 @@ server {
       # CORS allow-any website to embed our data
       if ($request_method = 'OPTIONS') {
         add_header 'Access-Control-Allow-Origin' '*';
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-
-        # Custom headers and headers various browsers *should* be OK with but aren't
-        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-        add_header 'Access-Control-Max-Age' 1728000; # Tell client that this pre-flight info is valid for 20 days
-        add_header 'Content-Length' 0;
         return 204;
      }
      if ($request_method = 'GET') {
         add_header 'Access-Control-Allow-Origin' '*';
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-        add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
      }
   }  
   
@@ -47,19 +38,10 @@ server {
       # CORS allow-any website to embed our data
       if ($request_method = 'OPTIONS') {
         add_header 'Access-Control-Allow-Origin' '*';
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-
-        # Custom headers and headers various browsers *should* be OK with but aren't
-        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-        add_header 'Access-Control-Max-Age' 1728000; # Tell client that this pre-flight info is valid for 20 days
-        add_header 'Content-Length' 0;
         return 204;
      }
      if ($request_method = 'GET') {
         add_header 'Access-Control-Allow-Origin' '*';
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-        add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
      }
 
   }

--- a/vps_setup_example.txt
+++ b/vps_setup_example.txt
@@ -59,8 +59,6 @@ $ ./particl-binaries/particl-cli -datadir=/home/stakepooluser/stakepoolDemoLive 
 $ lynx localhost:9000
 
 
-
-
 $ sudo rm /etc/nginx/sites-enabled/default
 $ sudo cp stakepool/config/nginx_stakepool_forward.conf /etc/nginx/conf.d/
 
@@ -77,4 +75,20 @@ http://vpsip:901/
 
 Check that it all starts back up:
 $ sudo reboot
+
+
+-- nginx production config
+The production configuration enables:
+* open CORS - anyone can embed the statistics in their website
+* caching (expires after 2 minutes)
+* uses port 80
+
+$ mkdir /tmp/nginx
+$ sudo rm stakepool/config/nginx_stakepool_forward.conf
+$ sudo cp stakepool/config/nginx_stakepool_production.conf /etc/nginx/conf.d/
+$ sudo systemctl restart nginx
+
+Test, browse to:
+http://vpsip/
+http://vpsip/testnet
 


### PR DESCRIPTION
Add caching to nginx
Unify server configuration, /test will now route to the testnet poolpage
Use port 80 instead of 900 & 901
Enable CORS on the reverse proxy